### PR TITLE
Fix config usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,20 @@
 const express = require('express');
 const BeamClient = require('beam-client-node');
 
-const config = require('./config/config.json');
-const port = config.port || 80;
-const scopes = config.scopes;
+const config = require('config');
+const port = config.get('port') || 80;
+const scopes = config.get('scopes');
 
 const portAddition = port !== 80 ? `:${port}` : '';
-const redirectUri = `${config.baseUrl}${portAddition}/callback`;
-
+const redirectUri = `${config.get('baseUrl')}${portAddition}/callback`;
 const app = express();
 
 function createClient() {
     const client = new BeamClient();
     // Supply the OAuth information to the client.
     client.use('oauth', {
-        clientId: config.clientId,
-        secret: config.clientSecret
+        clientId: config.get('clientId'),
+        secret: config.get('clientSecret'),
     });
     return client;
 }

--- a/index.js
+++ b/index.js
@@ -1,36 +1,39 @@
-const express = require("express");
-const BeamClient = require("beam-client-node");
+const express = require('express');
+const BeamClient = require('beam-client-node');
 
-const config = require('config');
-const port = config.get('port') || 80;
-const scopes = config.get('scopes');
+const config = require('./config/config.json');
+const port = config.port || 80;
+const scopes = config.scopes;
 
 const portAddition = port !== 80 ? `:${port}` : '';
-const redirectUri = `${config.get('baseUrl')}${portAddition}/callback`;
+const redirectUri = `${config.baseUrl}${portAddition}/callback`;
 
 const app = express();
 
 function createClient() {
     const client = new BeamClient();
-    client.use("oauth", {
-        clientId: config.get('clientId'),
-        secret: config.get('clientSecret'),
+    // Supply the OAuth information to the client.
+    client.use('oauth', {
+        clientId: config.clientId,
+        secret: config.clientSecret
     });
     return client;
 }
 
 const client = createClient();
 
-app.get("/", (request, res) => {
-    res.redirect(client.getProvider().getRedirect(redirectUri, scopes));
+app.get('/', (request, reply) => {
+    // Redirect clients who visit `/` to the authorization page.
+    reply.redirect(client.getProvider().getRedirect(redirectUri, scopes));
 });
 
-app.get("/callback", (request, reply) => {
+app.get('/callback', (request, reply) => {
+    // Respond with either an error, or with the information the client can use to authorize with.
     const oauth = client.getProvider();
 
     oauth.attempt(redirectUri, request.query)
         .then(res => reply.json(oauth.getTokens()))
-        .catch(err => reply.json(err));
+        .catch(reply.json);
 });
 
 app.listen(port, () => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An example of how to use express to retrieve a Beam OAuth access token.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node ."
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
In it's default state, it didn't start.

Made the quotes all the same type
Tiny bit of documentation
Fixed usage of the config
Also added `start` to the package file, for easier starting.